### PR TITLE
documentation and codecov removal in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/titanicfloatnone/ticTac.svg?branch=master)](https://travis-ci.org/titanicfloatnone/ticTac)
-[![codecov](https://codecov.io/gh/titanicfloatnone/ticTac/branch/master/graph/badge.svg)](https://codecov.io/gh/titanicfloatnone/ticTac)
 
 ## About the project
 This project is a part of a software engineering course in [RU(Reykjavík University)](https://www.ru.is/). The job is to implement the game TicTacToe.
@@ -7,14 +6,16 @@ The prime **goal** however is to follow the best practices in software developme
 
 
 * The code is stored in source control system on GitHub
-* The system is setup with automatic build script.
-* The build script runs all unit tests.
+* The system is setup with automatic build script
+* The build script runs all unit tests
 * use TDD(Test driven development)
 * The code should be loosely coupled and follow good object oriented
-design practices.
-* Documentation uses Markdown syntax.
-* Use Automated Continuous Integration Server (e.g.Travis CI).
+design practices
+* Documentation uses Markdown syntax
+* Use Automated Continuous Integration Server (e.g.Travis CI)
 * Use feature branches and pull request for all features
+
+[Here](https://www.dropbox.com/home/Apps/Docs_late_term_assignment) is our complete documentation and code coverage history stored on Dropbox.
 
 ## Group members
 * Alex Már Gunnarsson


### PR DESCRIPTION
Removing code coverage badge and putting link to our complete documentation and code coverage history on Dropbox in the readme file